### PR TITLE
News(article): add initial screen for news article

### DIFF
--- a/src/app/news/[news_id]/page.tsx
+++ b/src/app/news/[news_id]/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 interface Params {
   params: {
     news_id: string;
@@ -8,9 +10,33 @@ export default function NewsArticle({ params }: Params) {
   const newsId = params.news_id;
 
   return (
-    <main>
-      <h1 className="mt-20">ニュース記事</h1>
-      <div>記事ID: {newsId}</div>
+    <main className="bg-green-light min-h-screen">
+      <section className="flex justify-center pt-20 pb-20">
+        <section className="w-full max-w-screen-md mx-10">
+          <section className="bg-white rounded-lg shadow-md px-16 pt-10 pb-6 mt-6">
+            <h1 className="text-xl text-center border-b-[1.4px] border-green pb-2 px-1">
+              写真集の発売が決定
+            </h1>
+            <section className="mt-5 px-1">
+              <p>この度、青星ヒカリの1st写真集の発売が決定しました！</p>
+              <p>詳細につきましては、近日公開となります。</p>
+              <p>ぜひ、チェックしてみてください。</p>
+              <p>記事ID: {newsId}</p>
+              <p className="mt-4 text-right text-sm text-gray-800">
+                2023.04.01
+              </p>
+            </section>
+          </section>
+          <section className="mt-10 flex justify-center">
+            <Link
+              href="/news"
+              className="bg-green hover:bg-gray text-white hover:text-black py-3 px-8 text-center rounded shadow text-sm font-bold hover:font-normal"
+            >
+              ニュース一覧に戻る
+            </Link>
+          </section>
+        </section>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
`/news/:news_id`ページの初期画面を作成

Fix #24 